### PR TITLE
Fix incorrect module details

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -7,10 +7,8 @@
     "dependencies" : [
         {"id": "CoreAssets", "minVersion": "2.0.0"},
         {"id": "CoreWorlds", "minVersion": "1.0.0"},
-        {"id": "GenericRocks", "minVersion": "1.0.0"},
-        {"id": "CoreRendering", "minVersion": "1.0.0"}
+        {"id": "GenericRocks", "minVersion": "1.0.0"}
      ],
-    "serverSideOnly" : "false",
-    "isGameplay" : "true",
-    "defaultWorldGenerator" : "Volcanoes:VolcanoTestFlat"
+    "serverSideOnly" : true,
+    "isWorld" : true
 }


### PR DESCRIPTION
This module isn't actually a gameplay module (it looks like that was just used as a convenient way to activate the volcano test world generator), and it doesn't actually depend on CoreRendering (that's just necessary to get it to work as its own gameplay).